### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/marat4f/1a1869ab-6e82-4121-8bbe-cc2bfa13f4cf/c1a03166-577b-469e-9cc8-65fa985e76e2/_apis/work/boardbadge/ae9fbf6b-67a9-4068-a592-c82cce4cd1c8)](https://dev.azure.com/marat4f/1a1869ab-6e82-4121-8bbe-cc2bfa13f4cf/_boards/board/t/c1a03166-577b-469e-9cc8-65fa985e76e2/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/marat4f/1a1869ab-6e82-4121-8bbe-cc2bfa13f4cf/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.